### PR TITLE
update to Skill convert-cowork-skill-to-sharepoint

### DIFF
--- a/Skills/convert-cowork-skill-to-sharepoint/README.md
+++ b/Skills/convert-cowork-skill-to-sharepoint/README.md
@@ -24,7 +24,6 @@ It reviews the source skill, identifies Cowork-specific assumptions, prepares a 
   - `references/`
   - `examples/`
   - `eval/`
-  - `scripts/`
 - Flags deprecated supporting files that may be deleted after review
 - Verifies saved files after update when practical
 

--- a/Skills/convert-cowork-skill-to-sharepoint/convert-cowork-skill-to-sharepoint/SKILL.md
+++ b/Skills/convert-cowork-skill-to-sharepoint/convert-cowork-skill-to-sharepoint/SKILL.md
@@ -118,7 +118,6 @@ Use this folder-structure rubric:
 - Put long guidance in `references/`.
 - Put worked scenarios in `examples/`.
 - Put pass/fail checks or test scenarios in `eval/`.
-- Put reusable helper logic in `scripts/`.
 - Remove Cowork-only supporting files from the converted design when they no longer apply.
 
 ### Phase 6: Save, verify, and report


### PR DESCRIPTION
Pretty sure Copilot in SharePoint skills don't support scripting (e.g. python, js, etc.) so I've removed the bits about /scripts/