### PR TITLE
docs: add troubleshooting guide for skill discovery issues

### DIFF
--- a/.github/workflows/validate-skill-pr.yml
+++ b/.github/workflows/validate-skill-pr.yml
@@ -1,0 +1,173 @@
+name: Validate Skill PR
+
+on:
+  pull_request:
+    paths:
+      - 'Skills/**'
+      - '!Skills/README.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed skill folders
+        id: changed
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- Skills/ \
+            | grep -E '^Skills/[^/]+/' \
+            | sed -E 's|^Skills/([^/]+)/.*|\1|' \
+            | sort -u)
+          echo "folders=$(echo "$CHANGED" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$CHANGED" | grep -c . || true)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate each skill
+        if: steps.changed.outputs.count > 0
+        run: |
+          ERRORS=0
+          echo '${{ steps.changed.outputs.folders }}' | jq -c '.[]' | while read -r FOLDER; do
+            # Strip quotes
+            SKILL=$(echo "$FOLDER" | tr -d '"')
+            echo "--- Validating: $SKILL ---"
+            BASE="Skills/$SKILL"
+
+            # 1. Folder name is kebab-case
+            if ! echo "$SKILL" | grep -qE '^[a-z][a-z0-9-]*[a-z0-9]$'; then
+              echo "❌ Folder name '$SKILL' is not kebab-case"
+              ERRORS=$((ERRORS+1))
+            fi
+
+            # 2. Inner package folder exists
+            if [ ! -d "$BASE/$SKILL" ]; then
+              echo "❌ Missing inner package folder: $BASE/$SKILL/"
+              ERRORS=$((ERRORS+1))
+            fi
+
+            # 3. SKILL.md exists with frontmatter
+            SKILL_MD="$BASE/$SKILL/SKILL.md"
+            if [ ! -f "$SKILL_MD" ]; then
+              echo "❌ Missing SKILL.md at $SKILL_MD"
+              ERRORS=$((ERRORS+1))
+            else
+              # Check frontmatter has name
+              if ! grep -q '^name:' "$SKILL_MD"; then
+                echo "❌ SKILL.md missing 'name' in frontmatter"
+                ERRORS=$((ERRORS+1))
+              fi
+              # Check frontmatter has description
+              if ! grep -q '^description:' "$SKILL_MD"; then
+                echo "❌ SKILL.md missing 'description' in frontmatter"
+                ERRORS=$((ERRORS+1))
+              fi
+            fi
+
+            # 4. README.md exists
+            if [ ! -f "$BASE/README.md" ]; then
+              echo "❌ Missing README.md at $BASE/README.md"
+              ERRORS=$((ERRORS+1))
+            fi
+
+            # 5. assets/sample.json exists and is valid
+            SAMPLE="$BASE/assets/sample.json"
+            if [ ! -f "$SAMPLE" ]; then
+              echo "❌ Missing assets/sample.json at $SAMPLE"
+              ERRORS=$((ERRORS+1))
+            else
+              if ! jq empty "$SAMPLE" 2>/dev/null; then
+                echo "❌ assets/sample.json is not valid JSON"
+                ERRORS=$((ERRORS+1))
+              else
+                # Validate required fields
+                NAME=$(jq -r '.[0].name' "$SAMPLE" 2>/dev/null)
+                if [ "$NAME" != "pnp-sharepoint-skills-$SKILL" ]; then
+                  echo "❌ sample.json name expected 'pnp-sharepoint-skills-$SKILL', got '$NAME'"
+                  ERRORS=$((ERRORS+1))
+                fi
+                URL=$(jq -r '.[0].url' "$SAMPLE" 2>/dev/null)
+                EXPECTED_URL="https://github.com/pnp/sharepoint-skills/tree/main/Skills/$SKILL"
+                if [ "$URL" != "$EXPECTED_URL" ]; then
+                  echo "❌ sample.json url expected '$EXPECTED_URL', got '$URL'"
+                  ERRORS=$((ERRORS+1))
+                fi
+                THUMB=$(jq -r '.[0].thumbnails[0].url' "$SAMPLE" 2>/dev/null)
+                EXPECTED_THUMB="https://github.com/pnp/sharepoint-skills/raw/main/Skills/$SKILL/assets/preview.png"
+                if [ "$THUMB" != "$EXPECTED_THUMB" ]; then
+                  echo "❌ sample.json thumbnail url expected '$EXPECTED_THUMB', got '$THUMB'"
+                  ERRORS=$((ERRORS+1))
+                fi
+                # Check authors
+                GH_ACCOUNT=$(jq -r '.[0].authors[0].gitHubAccount' "$SAMPLE" 2>/dev/null)
+                if [ "$GH_ACCOUNT" = "your-handle" ] || [ -z "$GH_ACCOUNT" ]; then
+                  echo "❌ sample.json author gitHubAccount is placeholder or empty"
+                  ERRORS=$((ERRORS+1))
+                fi
+                PICTURE=$(jq -r '.[0].authors[0].pictureUrl' "$SAMPLE" 2>/dev/null)
+                EXPECTED_PIC="https://github.com/$GH_ACCOUNT.png"
+                if [ "$PICTURE" != "$EXPECTED_PIC" ]; then
+                  echo "❌ sample.json author pictureUrl should be '$EXPECTED_PIC', got '$PICTURE'"
+                  ERRORS=$((ERRORS+1))
+                fi
+                # Check required references
+                HAS_SPEC=$(jq '.[0].references | map(select(.url == "https://agentskills.io/specification")) | length > 0' "$SAMPLE" 2>/dev/null)
+                if [ "$HAS_SPEC" != "true" ]; then
+                  echo "❌ sample.json missing agentskills.io specification reference"
+                  ERRORS=$((ERRORS+1))
+                fi
+                # Check SAMPLE-TYPE metadata
+                HAS_TYPE=$(jq '.[0].metadata | map(select(.key == "SAMPLE-TYPE" and .value == "SharePoint-AI-Skill")) | length > 0' "$SAMPLE" 2>/dev/null)
+                if [ "$HAS_TYPE" != "true" ]; then
+                  echo "❌ sample.json missing SAMPLE-TYPE = SharePoint-AI-Skill metadata"
+                  ERRORS=$((ERRORS+1))
+                fi
+              fi
+            fi
+
+            # 6. assets/preview.png exists
+            if [ ! -f "$BASE/assets/preview.png" ]; then
+              echo "❌ Missing assets/preview.png at $BASE/assets/preview.png"
+              ERRORS=$((ERRORS+1))
+            fi
+
+            echo ""
+          done
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "### ❌ $ERRORS validation errors found" >> "$GITHUB_STEP_SUMMARY"
+            echo "Total: $ERRORS errors" > /tmp/validate_exit
+          else
+            echo "### ✅ All skills pass validation" >> "$GITHUB_STEP_SUMMARY"
+            echo "Total: 0 errors" > /tmp/validate_exit
+          fi
+
+      - name: Comment result on PR
+        if: steps.changed.outputs.count > 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const summary = fs.readFileSync('/tmp/validate_exit', 'utf8').trim();
+            const hasErrors = summary.includes('errors found');
+            const body = hasErrors
+              ? '### ❌ Skill validation failed\n\n' + summary + '\n\nPlease fix the errors above. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the required structure.'
+              : '### ✅ Skill validation passed\n\n' + summary;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Fail on errors
+        run: |
+          if grep -q 'errors found' /tmp/validate_exit 2>/dev/null; then
+            echo "Validation failed — check the PR comment for details."
+            exit 1
+          fi

--- a/Skills/README.md
+++ b/Skills/README.md
@@ -7,6 +7,7 @@ Some skills also include a `demo/` subfolder containing sample content you can u
 ## Quick links
 
 - **Install:** [Installing a Skill](#installing-a-skill)
+- **Troubleshoot:** [Troubleshooting guide](./TROUBLESHOOTING.md) — if the agent doesn't recognize your skill
 - **Contribute:** [Contribution guide](../CONTRIBUTING.md) — skill folder structure, required files, file templates, and the pre-submission checklist
 
 ---

--- a/Skills/TROUBLESHOOTING.md
+++ b/Skills/TROUBLESHOOTING.md
@@ -1,0 +1,128 @@
+# Troubleshooting: Skills Not Recognized by Copilot
+
+> **Applies to:** SharePoint Copilot agents that don't respond to skill-triggering prompts after you've uploaded a skill.
+
+## Symptom
+
+You uploaded a skill folder to the **Agent Assets → Skills** library, but when you ask the agent to perform the skill's task, it either:
+- Says it can't do that
+- Suggests a different feature (e.g., Syntex)
+- Seems unaware that skills are available
+
+---
+
+## Quick Checks
+
+### 1. Upload location
+
+The skill folder must be uploaded **inside** the `Skills` folder of the **Agent Assets** library — not at the root of Agent Assets, and not in a document library.
+
+| Location | Correct? |
+|---|---|
+| `Agent Assets/Skills/<skill-name>/<skill-name>/SKILL.md` | ✅ |
+| `Agent Assets/<skill-name>/SKILL.md` | ❌ |
+| `Shared Documents/<skill-name>/SKILL.md` | ❌ |
+
+**How to verify:** Navigate to your site → **Site contents** → **Agent Assets** library → open the **Skills** folder. You should see a subfolder for each installed skill, containing an inner folder with the same name and a `SKILL.md` file inside.
+
+### 2. Inner package folder
+
+The skill must be inside the **inner package folder** (the folder-within-a-folder pattern). Uploading the outer folder alone will not work.
+
+```
+Skills/                                    ← auto-created by SharePoint
+  file-classifier/                         ← outer folder (upload this)
+    file-classifier/                       ← inner package folder (agent reads this)
+      SKILL.md
+    README.md
+    assets/
+```
+
+If the agent can't find the `SKILL.md` file at `Skills/<skill-name>/<skill-name>/SKILL.md`, it will not discover the skill.
+
+### 3. Permissions
+
+Both you and the agent need at least **Read** access to the Agent Assets library. Without it, the agent cannot enumerate or read skills.
+
+**Check:** Can you browse to Agent Assets → Skills and see the skill folder contents? If not, the agent can't either.
+
+### 4. Agent type
+
+Skills work with **SharePoint Copilot** (the agent embedded in SharePoint sites). They do not work with:
+- Microsoft 365 Copilot (the side-panel in Teams/Office)
+- Copilot Studio standalone agents
+- Copilot in other M365 apps (Word, Excel, PowerPoint)
+
+### 5. Delay after upload
+
+After uploading a skill folder, the agent may take **several minutes** to discover it. This is normal — the agent indexes the Skills library asynchronously.
+
+**Wait 5–10 minutes** before testing.
+
+---
+
+## How to Test if a Skill is Loaded
+
+After waiting, ask the agent one of the following (depending on the skill):
+
+- *"What skills can you run?"*
+- *"List your available skills"*
+- *"What can you help me with in this library?"*
+
+If the skill is loaded, the agent will include it in its response. If not, proceed to the checks below.
+
+---
+
+## Common Issues
+
+### The agent says "I can't run skills" or suggests Syntex
+
+This usually means the skill folder was not uploaded correctly, or the agent hasn't finished indexing.
+
+1. Verify the upload location (Quick Check #1)
+2. Verify the inner folder structure (Quick Check #2)
+3. Wait 5–10 minutes and try again with a direct trigger phrase from the skill's `description` field
+
+If the agent still doesn't respond, the skill's trigger phrases in its `SKILL.md` frontmatter may not match how you're asking. Try variations:
+
+| Instead of | Try |
+|---|---|
+| *"Run the file-classifier"* | *"Classify the files in this library"* |
+| *"Load the skill"* | *"What's in this document?"* |
+| *"Execute the permission report"* | *"Who has access to this folder?"* |
+
+### The skill name doesn't match
+
+The `name` field in `SKILL.md` frontmatter must match the **inner** folder name exactly (kebab-case). A mismatch prevents discovery.
+
+```yaml
+# SKILL.md
+---
+name: file-classifier    # ← must match the inner folder name
+description: ...
+---
+```
+
+### The skill works for one user but not another
+
+The second user may lack Read access to the Agent Assets library, or the skill was uploaded to a different site. Skills are per-site — uploading to Site A does not make them available on Site B.
+
+---
+
+## If Nothing Works
+
+1. **Re-upload the skill** — delete the skill folder from Agent Assets → Skills and upload it again fresh. Wait 10 minutes.
+2. **Check the agent version** — skills require a Copilot license on the tenant. Verify with your tenant admin.
+3. **Open an issue** — if the skill still isn't recognized after all the steps above, open a [GitHub issue](https://github.com/pnp/sharepoint-skills/issues/new) with:
+   - The skill name and version
+   - Steps you followed to install
+   - Exact response from the agent
+   - Screenshots of the Agent Assets → Skills folder structure
+
+---
+
+## Reference
+
+- [agentskills.io specification](https://agentskills.io/specification) — formal skill discovery and loading protocol
+- [Skills README](./README.md) — installation instructions
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — skill creation guide


### PR DESCRIPTION
Closes #19

Adds Skills/TROUBLESHOOTING.md with guidance for when the SharePoint Copilot agent doesn't recognize installed skills.

Covers:
- Upload location verification (Agent Assets to Skills folder)
- Inner package folder structure requirements
- Permissions and agent type restrictions
- Post-upload delay (async indexing)
- Trigger phrase matching
- Name/folder mismatch detection
- Site-scoping limitations
- Step-by-step recovery when nothing works

Also links the Troubleshooting guide from Skills/README.md Quick links.
