### PR TITLE
Add accessibility implementation contract to sharepoint-safe-html

### DIFF
--- a/Skills/sharepoint-safe-html/README.md
+++ b/Skills/sharepoint-safe-html/README.md
@@ -1,19 +1,20 @@
 # SharePoint Safe HTML
 
-Creates single-file HTML artifacts that render reliably in SharePoint, OneDrive, Teams, File Viewer, and embedded iframe preview surfaces. The skill turns general requests for reports, dashboards, decks, one-pagers, and visual pages into sandbox-safe HTML with no external dependencies, plus an explicit exception for supported live-linked CSV/XLSX data files.
+Creates single-file HTML artifacts that render reliably in SharePoint, OneDrive, Teams, File Viewer, and embedded iframe preview surfaces. The skill turns general requests for reports, dashboards, decks, one-pagers, and visual pages into sandbox-safe, WCAG 2.2 AA-oriented HTML with no external dependencies, plus an explicit exception for supported live-linked CSV/XLSX data files.
 
 ![preview](./assets/preview.png)
 
 ## What you get
 
 - A single self-contained `.html` file designed for SharePoint and OneDrive preview surfaces
-- Inline CSS, system fonts, responsive iframe-friendly layout, and semantic accessible HTML
+- Inline CSS, system fonts, responsive iframe-friendly layout, and semantic accessible HTML targeting WCAG 2.2 AA
+- An accessibility implementation contract covering live-region announcements, accessible KPI cards and tables, chart equivalents, color/contrast, keyboard/focus, reduced motion, and responsive/zoom behavior — see [references/accessibility.md](sharepoint-safe-html/references/accessibility.md)
 - Optional live links to up to 10 SharePoint/OneDrive `.csv` or `.xlsx` files in the same folder as the HTML artifact so data-backed artifacts can update when source files change
 - Defensive live-data rendering rules that prevent blank pages and errors when linked files are empty, renamed, or missing expected columns
 - Live-only behavior for live-linked reports: no hardcoded backup rows, fallback datasets, cached snapshots, sample rows, or stale render data
 - A deterministic render contract with input normalization, explicit empty states, visible error panels, and source checks for unresolved placeholders or leaked JavaScript values
 - Guardrails against CDNs, runtime network calls, local file paths, external assets, secrets, and unsafe raw HTML
-- A validation checklist for source scanning, responsive rendering, accessibility, and privacy review
+- Validation checklists for source scanning, responsive rendering, accessibility, and privacy review
 
 ## When to use
 
@@ -37,6 +38,7 @@ Ask Copilot:
 | Version | Date | Comments |
 | --- | --- | --- |
 | 1.0 | June 2026 | Initial Release |
+| 1.1 | August 2026 | Added a WCAG 2.2 AA-oriented accessibility implementation contract (live-region announcements, accessible KPI cards/tables/charts, color/contrast, keyboard/focus, reduced motion, responsive/zoom rules) and matching validation checklist, contributed by James Dellow |
 
 ## Disclaimer
 

--- a/Skills/sharepoint-safe-html/assets/sample.json
+++ b/Skills/sharepoint-safe-html/assets/sample.json
@@ -6,11 +6,12 @@
     "shortDescription": "Creates HTML artifacts that render reliably in SharePoint, OneDrive, Teams, File Viewer, and embedded iframe preview surfaces.",
     "url": "https://github.com/pnp/sharepoint-skills/tree/main/Skills/sharepoint-safe-html",
     "longDescription": [
-      "Creates a SharePoint-safe HTML file for SharePoint and OneDrive preview surfaces. The skill enforces inline CSS, semantic accessible markup, responsive iframe-friendly layouts, and privacy-safe escaping of untrusted content.",
-      "Use it for HTML reports, dashboards, decks, one-pagers, and visual artifacts that must run without external CSS, JavaScript, images, fonts, APIs, CDNs, local file paths, secrets, or runtime network calls. When the user needs auto-updating data, the skill allows the supported SharePoint/OneDrive exception of up to 10 live-linked CSV or XLSX files in the same folder as the HTML artifact, with defensive schema validation and empty/error states so changed data files do not crash the render. Live-linked reports must be live-only: no embedded backup rows, fallback datasets, cached snapshots, sample rows, or stale hardcoded business data. The skill also requires a deterministic render pipeline, explicit empty/error states, and source checks for unresolved placeholders or leaked JavaScript values."
+      "Creates a SharePoint-safe HTML file for SharePoint and OneDrive preview surfaces. The skill enforces inline CSS, semantic HTML targeting WCAG 2.2 AA, responsive iframe-friendly layouts, and privacy-safe escaping of untrusted content.",
+      "Use it for HTML reports, dashboards, decks, one-pagers, and visual artifacts that must run without external CSS, JavaScript, images, fonts, APIs, CDNs, local file paths, secrets, or runtime network calls. When the user needs auto-updating data, the skill allows the supported SharePoint/OneDrive exception of up to 10 live-linked CSV or XLSX files in the same folder as the HTML artifact, with defensive schema validation and empty/error states so changed data files do not crash the render. Live-linked reports must be live-only: no embedded backup rows, fallback datasets, cached snapshots, sample rows, or stale hardcoded business data. The skill also requires a deterministic render pipeline, explicit empty/error states, and source checks for unresolved placeholders or leaked JavaScript values.",
+      "An accessibility implementation contract covers live-region announcements for dynamic content, accessible KPI cards and data tables, chart-to-text/table equivalents, color/contrast, keyboard/focus, reduced motion, and responsive/zoom behavior, each backed by a matching validation checklist."
     ],
     "creationDateTime": "2026-06-28",
-    "updateDateTime": "2026-06-28",
+    "updateDateTime": "2026-08-08",
     "products": [
       "SharePoint",
       "Microsoft 365 Copilot"

--- a/Skills/sharepoint-safe-html/sharepoint-safe-html/SKILL.md
+++ b/Skills/sharepoint-safe-html/sharepoint-safe-html/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: sharepoint-safe-html
 description: >
-  Creates single-file HTML artifacts that render reliably in SharePoint, OneDrive,
-  Teams, File Viewer, and embedded iframe preview surfaces. Use this skill whenever
-  the user asks for SharePoint-safe HTML, an HTML report, dashboard, deck, artifact,
-  visual page, one-pager, or embeddable HTML file for Microsoft 365 preview surfaces.
-  Enforces inline CSS, no external dependencies, no runtime network calls, responsive
-  iframe-friendly layout, optional live-linked CSV/XLSX data files, accessibility,
-  and privacy-safe escaping.
+  Creates accessible, single-file HTML artifacts that render reliably in SharePoint, OneDrive,
+  Teams, File Viewer, and embedded iframe preview surfaces. Use this skill whenever the user
+  asks for SharePoint-safe HTML, an HTML report, dashboard, deck, artifact, visual page,
+  one-pager, or embeddable HTML file for Microsoft 365 preview surfaces. Enforces inline CSS,
+  no external dependencies, no runtime network calls, responsive iframe-friendly layout,
+  optional live-linked CSV/XLSX data files, WCAG 2.2 AA-oriented accessibility, and
+  privacy-safe escaping.
 metadata:
   author: zrosenfield
 ---
@@ -16,7 +16,7 @@ metadata:
 
 Generate a single self-contained `.html` file that works reliably when hosted in SharePoint or OneDrive and opened through preview, File Viewer, Teams, or an embedded iframe.
 
-If a narrower installed skill matches the artifact type (for example, an executive report, dossier, scorecard, or roadmap), use that skill for content structure and apply this skill's safety contract to the final HTML.
+If a narrower installed skill matches the artifact type (for example, an executive report, dossier, scorecard, or roadmap), use that skill for content structure and apply this skill's safety and accessibility contract to the final HTML.
 
 ---
 
@@ -30,6 +30,7 @@ Create exactly one `.html` file that works with:
 - No privileged browser APIs.
 - No secrets or tokens.
 - No dependency on local filesystem paths.
+- Semantic, accessible HTML that targets WCAG 2.2 AA unless the user explicitly asks for a different standard.
 
 Assume SharePoint and OneDrive render the file inside a restricted sandboxed iframe. If it works locally but relies on anything outside the file, it is not SharePoint-safe.
 
@@ -43,6 +44,8 @@ Prefer static, self-contained, CSS-driven HTML.
 
 Use JavaScript only when the user explicitly needs interactivity and accepts that SharePoint/OneDrive sandbox behavior may vary. If JavaScript is used, it must be inline, dependency-free, non-networked, and progressive enhancement only. The artifact must remain useful if scripts are blocked.
 
+Accessibility is not a final polish step. It must shape the content model, visual design, render logic, and validation pass.
+
 ---
 
 ## Workflow
@@ -55,6 +58,7 @@ Identify the requested output type and audience:
 - Intended SharePoint/OneDrive location if provided.
 - Whether interactivity is truly required.
 - Source/freshness notes needed for any data shown.
+- Accessibility needs implied by the artifact, including charts, tables, status messages, and keyboard interaction.
 
 Do not ask for information the user already provided. If the request can be completed from the prompt or attached data, proceed.
 
@@ -68,6 +72,15 @@ For private M365, email, Teams, SharePoint, CRM, or customer data:
 - Do not hide raw source data in comments, scripts, attributes, or unused markup.
 - Do not embed full source transcripts unless explicitly requested.
 - Do not include tokens, cookies, connection strings, debug logs, or internal-only URLs that should not be shared.
+
+For accessibility, define the semantic purpose of each section before rendering it:
+
+- Page introduction.
+- Summary metrics.
+- Charts or visual summaries.
+- Data tables.
+- Notes, caveats, source, and freshness information.
+- Empty, loading, and error states.
 
 If the user wants the artifact to auto-update from source files, use live-linked `.csv` or `.xlsx` data files instead of embedding stale snapshots. Follow the live-linked data rules below before generating the final HTML.
 
@@ -136,7 +149,7 @@ The expected result for state 6 is a visible error message such as: `Live data f
 
 Use semantic HTML and inline CSS:
 
-- Use `main`, `section`, `article`, `header`, `footer`, `h1`-`h6`, `p`, `ul`, `ol`, `table`, `figure`, and `figcaption`.
+- Use `main`, `section`, `article`, `header`, `footer`, `h1`-`h6`, `p`, `ul`, `ol`, `dl`, `table`, `figure`, and `figcaption` where appropriate.
 - Use exactly one `h1` and maintain accessible heading order.
 - Inline all CSS in a `<style>` block.
 - Scope page styles under a root wrapper such as `.sp-html-artifact`.
@@ -145,6 +158,7 @@ Use semantic HTML and inline CSS:
 - Use responsive layouts from about 360px wide to desktop.
 - Make charts readable without hover-only interactions.
 - Include source and freshness notes when presenting data.
+- Ensure the artifact remains readable at 200% browser zoom.
 
 Use this base pattern unless the requested design requires a different layout:
 
@@ -172,17 +186,40 @@ Use this base pattern unless the requested design requires a different layout:
       margin: 0 auto;
       padding: 24px;
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    :focus-visible {
+      outline: 3px solid #2563eb;
+      outline-offset: 3px;
+    }
     @media (max-width: 640px) {
       .sp-html-artifact { padding: 14px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+      }
     }
   </style>
 </head>
 <body>
-  <main class="sp-html-artifact">
-    <section aria-labelledby="page-title">
+  <main class="sp-html-artifact" id="main-content">
+    <header aria-labelledby="page-title">
       <h1 id="page-title">Artifact title</h1>
       <p>Lead with the most important message.</p>
-    </section>
+    </header>
   </main>
 </body>
 </html>
@@ -229,19 +266,34 @@ Never render raw untrusted HTML.
 
 ### Step 6: Validate before handoff
 
-Before handing the file to the user, verify the source and layout:
+Before handing the file to the user, verify the source, layout, and accessibility:
 
 1. Search the source for banned patterns listed in the validation checklist.
 2. Confirm all CSS is inline.
 3. Confirm no external dependencies are referenced.
-4. Confirm the page is readable at 360px, 768px, and desktop widths.
+4. Confirm the page is readable at 360px, 768px, and desktop widths, and at 200% browser zoom.
 5. Confirm there is no horizontal scrolling.
 6. Confirm all meaningful images have alt text and decorative images use `alt=""`.
-7. Confirm charts and tables are readable without hover.
-8. Confirm private data is intentional and appropriate for the SharePoint location.
-9. Confirm there are no unresolved placeholders, leaked JavaScript values, or accidental mock rows.
-10. If possible, upload to SharePoint or OneDrive and open through preview or File Viewer.
-11. If embedded on a SharePoint page, verify the actual web part/container size.
+7. Confirm charts and tables are readable without hover, and every chart has a text, list, or table equivalent.
+8. Confirm KPI cards and status indicators expose label/value relationships and don't rely on color alone.
+9. Confirm dynamic loading, refresh, success, and error states are announced through `role="status"`/`role="alert"` live regions.
+10. Confirm visible focus is present and keyboard users can operate every interactive control.
+11. Confirm private data is intentional and appropriate for the SharePoint location.
+12. Confirm there are no unresolved placeholders, leaked JavaScript values, or accidental mock rows.
+13. If possible, upload to SharePoint or OneDrive and open through preview or File Viewer.
+14. If embedded on a SharePoint page, verify the actual web part/container size.
+
+Run the full [Validation Checklist](#validation-checklist) and [Accessibility validation checklist](#accessibility-validation-checklist) below before handoff.
+
+---
+
+## Accessibility Implementation Contract
+
+Target WCAG 2.2 AA unless the user explicitly asks for a different standard.
+
+The artifact must be perceivable, operable, understandable, and robust. Build accessibility into the content model and rendering approach rather than treating it as a final checklist.
+
+This skill's [Accessibility Rules](#accessibility-rules) and [Accessibility validation checklist](#accessibility-validation-checklist) below cover the rules to apply and verify on every artifact. For the full implementation patterns behind those rules — semantic page structure, live-region markup for dynamic content, accessible KPI card and table markup, accessible chart patterns, color/contrast, keyboard/focus, reduced motion, responsive/zoom behavior, image/SVG alt handling, link/button text, and plain-language guidance, each with runnable HTML/CSS examples — see [references/accessibility.md](references/accessibility.md). Read it before building any section that involves dynamic status, charts, tables, or KPI cards.
 
 ---
 
@@ -253,11 +305,13 @@ Use these freely:
 - CSS variables.
 - Flexbox and CSS Grid.
 - Media queries.
-- CSS-only charts, bars, badges, status strips, cards, timelines, and tables.
+- CSS-only charts, bars, badges, status strips, cards, timelines, matrix cells, inline SVG, and tables.
 - Print styles when useful.
 - `details` and `summary` for progressive disclosure.
 - Inline SVG created by the agent if it contains no scripts, external references, or unsafe content.
 - Small `data:image/svg+xml` or `data:image/png;base64` assets only when necessary and size-safe.
+- Native HTML controls for interaction.
+- Screen-reader-only CSS for essential accessible labels or summaries when visible text would be duplicative.
 
 Prefer CSS-only visuals over external chart libraries. For example, use horizontal bars, status chips, sparklines, timelines, matrix cells, inline SVG, or semantic tables.
 
@@ -278,8 +332,12 @@ Do not use:
 - Iframes that load external sites.
 - Browser APIs that require permissions or privileged context: clipboard write, microphone, camera, geolocation, notifications, service workers, web workers, storage persistence, IndexedDB as a requirement, or downloads as the primary workflow.
 - Hover as the only way to see data.
+- Color as the only way to understand status, category, or priority.
 - Fixed-width layouts that clip inside SharePoint.
 - Huge base64 assets that make preview slow or unreliable.
+- Focus outlines removed with `outline: none` unless an equally visible replacement is applied.
+- Visual-only charts with no text, list, or table equivalent.
+- Anonymous KPI cards that do not expose label and value relationships.
 
 ---
 
@@ -302,23 +360,39 @@ Acceptable JavaScript use cases include local tab switching, expand/collapse, so
 
 Prefer `details`/`summary`, anchor links, static tables/charts, and CSS bars/sparklines when they satisfy the need.
 
+When JavaScript changes visible content:
+
+- Update an appropriate `role="status"` live region for meaningful state changes.
+- Use `role="alert"` for blocking errors.
+- Keep focus management simple and predictable.
+- Do not move focus unless the interaction requires it.
+
 ---
 
 ## Accessibility Rules
 
+Use these rules for every artifact:
+
+- Target WCAG 2.2 AA unless another standard is requested.
 - Use one `h1`.
 - Use headings in order.
-- Make text readable at normal zoom.
+- Include a `main` landmark.
+- Use semantic sections for major content groups.
+- Make text readable at normal zoom and 200% zoom.
 - Use sufficient contrast.
 - Do not encode meaning only by color.
 - Provide visible labels for status chips and charts.
 - Add `alt` text for meaningful images.
-- Mark decorative images `alt=""`.
+- Mark decorative images with `alt=""` or `aria-hidden="true"` as appropriate.
 - Use table headers for data tables.
-- Use `caption` or nearby summary text for complex tables.
+- Use table captions or nearby summary text for data tables.
 - Make links descriptive.
 - Ensure keyboard navigation works for any interactive elements.
+- Preserve visible focus.
 - Avoid motion; if used, respect `prefers-reduced-motion`.
+- Ensure dynamic loading, refresh, success, and error states are announced correctly.
+- Ensure every chart has an equivalent text, list, or table representation.
+- Ensure KPI cards expose label and value relationships semantically.
 
 ---
 
@@ -364,12 +438,40 @@ Then verify:
 - [ ] Charts and tables are readable without hover.
 - [ ] Source/freshness notes are included when data is presented.
 
+### Accessibility validation checklist
+
+Verify the following before handoff:
+
+- [ ] Exactly one `h1` exists.
+- [ ] Heading order is logical.
+- [ ] `main` landmark exists.
+- [ ] Major content groups have accessible headings.
+- [ ] Dynamic status areas use `role="status"` and `aria-live="polite"`.
+- [ ] Blocking errors use `role="alert"`.
+- [ ] Buttons have clear accessible names.
+- [ ] Keyboard users can operate all controls.
+- [ ] Visible focus is present and clear.
+- [ ] Links are descriptive.
+- [ ] Charts have equivalent text, list, or table data.
+- [ ] Visual chart elements that duplicate text are hidden with `aria-hidden="true"`.
+- [ ] Tables have captions or nearby summaries.
+- [ ] Table headers use `th` and `scope` where appropriate.
+- [ ] No meaning is conveyed by color alone.
+- [ ] Contrast has been checked for text, badges, muted labels, errors, chart labels, and status chips.
+- [ ] Content is readable at 200% zoom.
+- [ ] Layout works at 360px width.
+- [ ] No content is available only on hover.
+- [ ] Meaningful images have alt text or equivalent.
+- [ ] Decorative visuals are hidden from assistive technology.
+- [ ] Reduced motion is respected.
+- [ ] Error messages explain the problem and the likely fix.
+
 ---
 
 ## Short Instruction Block
 
 When a user asks for SharePoint-safe HTML, follow this instruction:
 
-> Create a single self-contained HTML file for SharePoint/OneDrive preview. Use inline CSS only. Do not use external CSS, JS, images, fonts, APIs, CDNs, local file references, secrets, or runtime network calls. Avoid JavaScript unless explicitly required; if used, keep it inline, dependency-free, non-networked, and optional. Escape all untrusted content. Use semantic accessible HTML, responsive iframe-friendly layout, system fonts, and CSS-only visuals where possible. Validate that the source contains no external dependencies and that the file renders in SharePoint/OneDrive preview.
+> Create a single self-contained HTML file for SharePoint/OneDrive preview. Use inline CSS only. Do not use external CSS, JS, images, fonts, APIs, CDNs, local file references, secrets, or runtime network calls. Avoid JavaScript unless explicitly required; if used, keep it inline, dependency-free, non-networked, optional, and accessible. Escape all untrusted content. Use semantic accessible HTML, responsive iframe-friendly layout, system fonts, and CSS-only visuals where possible. Target WCAG 2.2 AA by default. Include a `main` landmark, exactly one `h1`, logical headings, visible focus, sufficient contrast, descriptive links, accessible buttons, accessible loading/error states, and reduced-motion support. KPI cards must expose label/value relationships, preferably with a definition list. Tables must include captions or nearby summaries and proper headers. Charts must never be visual-only — every chart must provide the same data as text, a list, or a table, and must not rely on color, hover, width, or position alone to communicate meaning. Validate that the source contains no external dependencies and that the file renders in SharePoint/OneDrive preview.
 
 If the user wants auto-updating data, use only the SharePoint/OneDrive live-linked data exception: up to 10 linked `.csv` or `.xlsx` files in the same folder as the HTML artifact, with visible source/freshness notes and no agent-authored runtime fetch/API code. Live-linked reports must be live-only: never embed backup rows, fallback datasets, cached snapshots, sample rows, or stale hardcoded business data. If the live link fails, render a visible error explaining what to fix. Because linked files can change after generation, define each file's expected schema, normalize all data to safe defaults, never call array methods on unverified values, and render visible empty/error states instead of uncaught render errors.

--- a/Skills/sharepoint-safe-html/sharepoint-safe-html/references/accessibility.md
+++ b/Skills/sharepoint-safe-html/sharepoint-safe-html/references/accessibility.md
@@ -1,0 +1,228 @@
+# Accessibility Implementation Reference
+
+Detailed implementation patterns for the [Accessibility Implementation Contract](../SKILL.md#accessibility-implementation-contract) in `SKILL.md`. Read the relevant section before building the corresponding part of an artifact — dynamic status, charts, tables, or KPI cards.
+
+## Page structure
+
+Use semantic landmarks for every artifact:
+
+- `main` for the primary content.
+- `header` for the report introduction.
+- `section` for major content groups.
+- `article` for reusable or standalone content objects.
+- `footer` for source, freshness, and caveat notes.
+
+Use exactly one `h1`. Maintain heading order. Do not skip from `h1` to `h3` unless there is a real `h2` between them.
+
+If the artifact is likely to be embedded in a larger page, keep the `h1` in the file because the file must also make sense when viewed independently.
+
+## Dynamic content and live-data announcements
+
+For loading, refresh, rendering, and success messages, use a live region:
+
+```html
+<div role="status" aria-live="polite">Loading live data...</div>
+```
+
+For serious failures that stop the user completing the task, use:
+
+```html
+<div role="alert">Live data failed to load.</div>
+```
+
+Rules:
+
+- Loading messages must not be visual only.
+- Refresh buttons must have a clear accessible name, such as `Refresh customer version data`.
+- When a live-data section updates, update a nearby status message so assistive technology users know the content changed.
+- Do not repeatedly announce non-essential changes.
+
+## KPI cards and summary metrics
+
+Do not render KPI cards as anonymous `div` elements only.
+
+Prefer a definition list for metric summaries:
+
+```html
+<section aria-labelledby="summary-heading">
+  <h2 id="summary-heading">Summary statistics</h2>
+  <dl class="kpi-grid">
+    <div class="kpi-card">
+      <dt>Total customers</dt>
+      <dd>42</dd>
+    </div>
+    <div class="kpi-card">
+      <dt>Missing either version</dt>
+      <dd>6</dd>
+    </div>
+  </dl>
+</section>
+```
+
+If visual cards are used, the semantic structure must still expose the relationship between label and value.
+
+## Tables
+
+Every data table must include:
+
+- A `caption` or equivalent nearby accessible summary.
+- `thead` and `th` for column headers.
+- `scope="col"` on column headers where applicable.
+- `scope="row"` where row headers are used.
+
+Do not use tables for layout.
+
+If a table is complex, add a short visible summary before the table explaining what the table shows.
+
+For wide tables, wrap the table in a labelled responsive region:
+
+```html
+<div class="table-wrap" role="region" aria-labelledby="customer-table-heading" tabindex="0">
+  <table>
+    <caption>Customer app version status</caption>
+    <thead>
+      <tr>
+        <th scope="col">Customer</th>
+        <th scope="col">App version</th>
+      </tr>
+    </thead>
+  </table>
+</div>
+```
+
+Only add `tabindex="0"` to a scrollable table wrapper when keyboard access is needed to reach overflow content.
+
+## CSS charts and visualizations
+
+CSS-only charts are allowed, but the data must not be available only through visual bars, color, width, position, or hover.
+
+Every chart must include one of the following:
+
+1. An accessible data table containing the same data.
+2. A visible text summary plus screen-reader-friendly detail.
+3. An aria-labelled chart region where each data point is also available as text.
+
+For bar charts, each row must expose:
+
+- Label.
+- Value.
+- Meaning.
+
+Recommended accessible bar chart pattern:
+
+```html
+<section aria-labelledby="version-chart-heading">
+  <h2 id="version-chart-heading">Customers by app version</h2>
+  <p>Summary of how many customers are on each app version.</p>
+  <ul class="chart-list">
+    <li>
+      <span>Version 6.0.7: 12 customers</span>
+      <span class="bar-track" aria-hidden="true">
+        <span class="bar-fill" style="width: 80%"></span>
+      </span>
+    </li>
+  </ul>
+</section>
+```
+
+Rules:
+
+- The visual bars may be included, but mark purely decorative bar tracks as `aria-hidden="true"` if the same data is available in text.
+- Do not rely on color alone to distinguish chart series.
+- Use labels, headings, legends, text, patterns, or grouping.
+- Avoid hover-only tooltips. Any tooltip content must also be available as visible or screen-reader-accessible text.
+- For charts with many data points, provide a summary and a data table.
+
+## Color and contrast
+
+Text and meaningful visual elements must meet WCAG 2.2 AA contrast expectations.
+
+Rules:
+
+- Do not use light grey text for important information unless contrast has been checked.
+- Status colors must be paired with visible text, such as `Not recorded`, `Current`, `Missing`, or `Action required`.
+- Chart labels, badge text, muted text, and error text must be included in contrast checks.
+- Do not use color as the only carrier of meaning.
+
+## Keyboard and focus
+
+All interactive elements must be native HTML controls where possible:
+
+- Use `button` for actions.
+- Use `a` for navigation.
+- Do not use `div` or `span` as buttons unless unavoidable. If unavoidable, add keyboard support and ARIA carefully.
+
+Rules:
+
+- Visible focus must not be removed.
+- If custom focus styling is used, it must remain clearly visible.
+- Keyboard users must be able to reach and operate every interactive control.
+- Interactive targets should be large enough for pointer and touch use.
+- Do not trap focus.
+- Do not create keyboard-only dead ends inside embedded iframe surfaces.
+
+## Reduced motion
+
+Avoid animation by default.
+
+If motion is used, it must respect:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+Do not use auto-advancing, flashing, pulsing, or attention-grabbing animation in SharePoint-safe artifacts.
+
+## Responsive and zoom behavior
+
+The artifact must remain usable at:
+
+- 360px width.
+- 768px width.
+- Desktop width.
+- 200% browser zoom.
+
+Avoid fixed-width layouts that cause horizontal scrolling.
+
+If a wide table cannot reasonably fit, wrap it in a labelled responsive region and ensure the table remains readable.
+
+## Images, icons, and SVG
+
+Meaningful images and SVGs require text alternatives.
+
+Decorative images and decorative SVGs must be hidden from assistive technology.
+
+Rules:
+
+- Use `alt` text for meaningful bitmap images.
+- Use `alt=""` for decorative bitmap images.
+- Inline SVG must include an accessible `title` or be `aria-hidden="true"` depending on whether it conveys meaning.
+- Do not encode essential text inside an image unless equivalent text is also available in HTML.
+
+## Links and buttons
+
+Links and buttons must be understandable out of context.
+
+Rules:
+
+- Avoid vague link text such as `Click here` or `Read more`.
+- Use descriptive link text such as `View source workbook` or `Open customer report`, when links are allowed.
+- Buttons must describe the action, such as `Refresh customer version data`.
+- If visible button text is short, add an `aria-label` only when it makes the accessible name clearer.
+
+## Plain language and abbreviations
+
+Use clear labels and concise explanations.
+
+Rules:
+
+- Expand product or technical abbreviations on first use where the audience may not know them.
+- Use `abbr title="..."` where appropriate, but do not rely on tooltips alone.
+- Error messages must say what went wrong and what the user can do next.


### PR DESCRIPTION
## Why

`sharepoint-safe-html` didn't have an accessibility contract beyond a short "Accessibility Rules" bullet list — enough to avoid the worst issues, but not enough to guarantee WCAG 2.2 AA outcomes for dynamic content, charts, tables,
or KPI cards, which is where accessibility usually breaks in generated HTML (color-only status, hover-only tooltips, unlabeled live regions, anonymous KPI `div`s).

## What changed

- Added an **Accessibility Implementation Contract** to `SKILL.md`: live-region markup for loading/refresh/error states, accessible KPI card and table patterns, chart-to-text/table equivalents, color/contrast, keyboard/focus, reduced motion, and responsive/zoom behavior.
- Added a matching **Accessibility validation checklist** alongside the existing Validation Checklist.
- Expanded **Banned Patterns**, **Allowed Patterns**, and **JavaScript Rules** with the accessibility-relevant additions (e.g. banning color-only status and anonymous KPI cards, allowing screen-reader-only CSS).
- Split the detailed implementation patterns/code samples into `references/accessibility.md` so `SKILL.md` stays under the ~500-line guideline in the Agent Skills spec (477 lines after this change, vs. 700 if kept inline).
- Everything else — the core contract, live-linked CSV/XLSX behavior, render pipeline, JS rules — is unchanged. This is additive, not a rewrite.

## Attribution

Original author (Zach Rosenfield) stays credited as the skill's author. Added a version history row in `README.md` (1.1, August 2026) crediting this contribution.

## Checklist

- [x] `SKILL.md` frontmatter valid, name matches folder
- [x] `SKILL.md` under 500 lines (477); detail moved to `references/accessibility.md`
- [x] `README.md` updated (What you get, version history)
- [x] `assets/sample.json` updated (longDescription, updateDateTime)
- [x] No functional regressions — restored a Step 6 that appeared to have been dropped in an earlier draft