### PR TITLE
Validate dynamic gallery and contributor counts

### DIFF
--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -68,7 +68,9 @@ jobs:
         run: |
           {
             echo "## Gallery artifact"
+            echo "- Catalog entries: $(node -p "require('./site/dist/catalog.json').skills.length")"
             echo "- Pages: $(find site/dist -name index.html -o -name 404.html | wc -l)"
+            echo "- Optimized previews: $(find site/dist/generated/previews -name '*.webp' | wc -l)"
             echo "- Site size: $(du -sh site/dist | cut -f1)"
             echo "- Packages: $(find site/dist/downloads -name '*.zip' | wc -l)"
             echo "- Package size: $(du -sh site/dist/downloads | cut -f1)"

--- a/.github/workflows/validate-skill-pr.yml
+++ b/.github/workflows/validate-skill-pr.yml
@@ -7,6 +7,7 @@ on:
       - "site/**"
       - ".github/schemas/**"
       - ".github/scripts/**"
+      - ".github/workflows/deploy-gallery.yml"
       - ".github/workflows/validate-skill-pr.yml"
       - "CONTRIBUTING.md"
   workflow_dispatch:

--- a/site/tests/e2e/gallery.spec.ts
+++ b/site/tests/e2e/gallery.spec.ts
@@ -31,7 +31,28 @@ test('renders a generated skill page, package, and public catalog', async ({ pag
 	expect(catalogResponse.ok()).toBeTruthy();
 	const catalog = await catalogResponse.json();
 	expect(catalog.version).toBe(1);
-	expect(catalog.skills).toHaveLength(47);
+
+	await page.goto('./');
+	await expect(page.locator('.catalog-stat strong')).toHaveText(String(catalog.skills.length));
+	await expect(page.locator('[data-skill-card]')).toHaveCount(catalog.skills.length);
+
+	const contributionCounts = new Map<string, number>();
+	for (const skill of catalog.skills) {
+		for (const author of skill.authors) {
+			const account = author.gitHubAccount.toLocaleLowerCase('en-US');
+			contributionCounts.set(account, (contributionCounts.get(account) ?? 0) + 1);
+		}
+	}
+
+	await page.goto('contributors/');
+	await expect(page.locator('.page-heading')).toContainText(`${contributionCounts.size} people`);
+	await expect(page.locator('.contributor-card')).toHaveCount(contributionCounts.size);
+	for (const [account, count] of contributionCounts) {
+		const contributor = page.locator('.contributor-card').filter({
+			has: page.getByRole('link', { name: `@${account}`, exact: false }),
+		});
+		await expect(contributor.locator('.contribution-count')).toHaveText(`${count} ${count === 1 ? 'skill' : 'skills'}`);
+	}
 });
 
 test('presents the SharePoint product story and contributor recognition', async ({ page }) => {

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,14 @@
 # SharePoint Skills gallery and publishing plan
 
 Status: Baseline implemented; launch approvals and hardening remain  
-Last updated: 2026-08-25  
+Last updated: 2026-08-26  
 Target: `https://pnp.github.io/sharepoint-skills/`
+
+## Publishing verification follow-ups
+
+- [ ] Automate the temporary skill lifecycle test (add, update, and delete) so catalog totals, contributor counts, routes, previews, and downloads are checked without retaining a fixture. The 2026-08-26 manual smoke test passed for 47 -> 48 -> 47 skills with `VesaJuvonen` attribution.
+- [ ] Add a build-artifact consistency gate that requires catalog entries, detail pages, ZIP packages, and preview pairs to have matching totals before upload.
+- [ ] Extend the post-deploy smoke test to compare the live catalog total with the rendered home total and verify the contributor directory, instead of checking only one known skill.
 
 ## Outcome
 


### PR DESCRIPTION
# Pull request

## Summary

Replace the fixed gallery-size assertion with generated-catalog checks for the overall skill total, contributor total, and each contributor's skill count. Also report catalog/preview totals in the Pages workflow and ensure deploy workflow changes trigger PR validation.

## Affected skill folders

Repository-wide.

## Reproduction and verification

- Added and removed a temporary `gallery-publishing-smoke` skill attributed to `VesaJuvonen`; validation and generation changed from 47 to 48 and back to 47 without frontend edits.
- Ran `python .github/scripts/validate_skills.py --root .` successfully.
- Ran `npm run check` and `npm run build` successfully.
- Ran 3 unit tests and 8 desktop/mobile Chromium and accessibility tests successfully.
- Confirmed the latest live GitHub Pages deployment and post-deploy smoke test are successful.

## Screenshots

N/A. No visual changes.

## Checklist

- [x] I listed the affected skill folders or marked the change as repository-wide.
- [x] I described how the change was reproduced or verified.
- [x] I included screenshots for visual changes, or marked them N/A.
- [x] I ran `python .github/scripts/validate_skills.py --root .` for skill changes, or marked it N/A.